### PR TITLE
ENH: oauth all day long

### DIFF
--- a/provisioning/roles/setup_atc/templates/atc.yml
+++ b/provisioning/roles/setup_atc/templates/atc.yml
@@ -24,5 +24,8 @@ services:
       CONCOURSE_PUBLICLY_VIEWABLE: 'true'
       CONCOURSE_BASIC_AUTH_USERNAME: {{ auth_user }}
       CONCOURSE_BASIC_AUTH_PASSWORD: {{ auth_pass }}
+      CONCOURSE_GITHUB_AUTH_CLIENT_ID: {{ github_client_id }}
+      CONCOURSE_GITHUB_AUTH_CLIENT_SECRET: {{ github_client_secret }}
+      CONCOURSE_GITHUB_AUTH_TEAM: {{ github_auth_team }}
       CONCOURSE_EXTERNAL_URL: {{ protocol }}://{{ external_host }}:{{ public_port }}
       CONCOURSE_POSTGRES_DATA_SOURCE: postgres://{{ pg_user }}:{{ pg_pass }}@db:5432/{{ pg_db }}?sslmode=disable


### PR DESCRIPTION
This needs https://github.com/caporaso-lab/secrets/commit/541ccb19ab9f6808ea4d896d2ffc4b555f735294 to run. Also, this has already been deployed.