### PR TITLE
ENH: clear index cache before fetching

### DIFF
--- a/ci/master/bin/env-file.sh
+++ b/ci/master/bin/env-file.sh
@@ -10,6 +10,8 @@ echo "source activate ./conda-env"
 source activate ./conda-env
 set -v
 
+conda clean --index-cache
+
 PKG_NAMES=$(cat $(ls -1 -d $(pwd)/* | grep '^.\+-channel$' | sed "s/$/\/version-spec.txt/" | xargs) | xargs)
 conda install -q -y \
   -c $STAGING_CHANNEL \


### PR DESCRIPTION
@jairideout this *should* stop `create-staging-env` from failing on OSX all of the time (this is basically what I do manually).