### PR TITLE
HACK: pin conda-build to 2

### DIFF
--- a/ci/master/bin/build.sh
+++ b/ci/master/bin/build.sh
@@ -3,7 +3,7 @@
 set -e -v
 
 conda update -q -y -c defaults --override-channels conda
-conda update -q -y -c defaults --override-channels conda-build
+conda install -q -y -c defaults --override-channels conda-build=2*
 
 BUILD_DIR=$(ls -d -1 $(pwd)/build-*)
 CHANNELS=$(ls -1 -d $(pwd)/* | grep '^.\+-channel$' | sed "s/^/ -c /" | xargs)


### PR DESCRIPTION
We'll want to revert this once conda-build 3 is working.