### PR TITLE
ENH: debugging envs

### DIFF
--- a/ci/master/bin/debug-env.sh
+++ b/ci/master/bin/debug-env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e -v
+
+cat debug-env.yml

--- a/ci/master/bin/integration.sh
+++ b/ci/master/bin/integration.sh
@@ -21,6 +21,8 @@ echo "source activate ./test-env"
 source activate ./test-env
 set -v
 
+# debug-env.yml for when this task fails, allows us to recreate the working env.
+conda list --explicit --export > debug-env.yml
 conda env export --no-builds --ignore-channels -p ./test-env > $ENV_FILE_FP
 
 cd docs-source

--- a/ci/master/bin/test.sh
+++ b/ci/master/bin/test.sh
@@ -20,4 +20,7 @@ echo "source activate ./test-env"
 source activate ./test-env
 set -v
 
+# debug-env.yml for when this task fails, allows us to recreate the working env.
+conda list --explicit --export > debug-env.yml
+
 $TEST_RUNNER_CMD

--- a/ci/master/jinja2/pipelines/distribution.yaml
+++ b/ci/master/jinja2/pipelines/distribution.yaml
@@ -174,10 +174,20 @@ jobs:
         - task: test-linux
           config:
             {{- unit_test.make_linux_config(project, defaults)|indent(12) }}
+          on_failure:
+            task: debug-environment
+            config:
+              run:
+                path: busywork/ci/{{ defaults.release_branch }}/bin/debug-env.sh
         - task: test-darwin
           attempts: 2
           config:
             {{- unit_test.make_darwin_config(project, defaults)|indent(12) }}
+          on_failure:
+            task: debug-environment
+            config:
+              run:
+                path: busywork/ci/{{ defaults.release_branch }}/bin/debug-env.sh
   {%- endif %}
 
   - name: stage-{{ project.name }}
@@ -235,9 +245,19 @@ jobs:
         - task: integration-linux
           config:
             {{- integration.make_linux_config(projects, defaults)|indent(12) }}
+          on_failure:
+              task: debug-environment
+              config:
+                run:
+                  path: busywork/ci/{{ defaults.release_branch }}/bin/debug-env.sh
         - task: integration-darwin
           config:
             {{- integration.make_darwin_config(projects, defaults)|indent(12) }}
+          on_failure:
+              task: debug-environment
+              config:
+                run:
+                  path: busywork/ci/{{ defaults.release_branch }}/bin/debug-env.sh
       - task: merge-and-commit-env-yaml
         config:
           {{- merge_env_files.make_config("unprocessed", defaults)|indent(10) }}


### PR DESCRIPTION
This should optionally print out the conda env in a failing unit test or integration container. 🤞 