### PR TITLE
MAINT: finishes adding q2-diversity-lib.

### DIFF
--- a/extra/github/variables.yaml
+++ b/extra/github/variables.yaml
@@ -17,6 +17,7 @@ repos:
   - q2-deblur
   - q2-demux
   - q2-diversity
+  - q2-diversity-lib
   - q2-emperor
   - q2-feature-classifier
   - q2-feature-table


### PR DESCRIPTION
[Initial PR](https://github.com/qiime2/busywork/commit/fae30acd0b4c33f8b804c13e02e928936a30e239) overlooked one variables.yaml file. Remedied here.