### PR TITLE
MAINT: run q2templates unit tests

### DIFF
--- a/ci/master/variables.yaml
+++ b/ci/master/variables.yaml
@@ -24,7 +24,7 @@ projects:
       QIIMETEST: true
 
   - name: q2templates
-    testable: false
+    test_runner: py.test --pyargs q2templates
 
   - name: q2-types
     deps: [qiime2]


### PR DESCRIPTION
Just noticed that we don't have a test step for q2templates (despite having a unit test suite). Am I missing something?