### PR TITLE
MAINT: adds q2-diversity-lib to busywork (again)

### DIFF
--- a/ci/master/variables.yaml
+++ b/ci/master/variables.yaml
@@ -55,8 +55,12 @@ projects:
     test_runner: py.test --pyargs q2_demux
 
   - name: q2-diversity
-    deps: [qiime2, q2templates, q2-types, q2-feature-table, q2-emperor, q2-metadata]
+    deps: [qiime2, q2templates, q2-types, q2-diversity-lib, q2-feature-table, q2-emperor, q2-metadata]
     test_runner: py.test --pyargs q2_diversity
+
+  - name: q2-diversity-lib
+    deps: [qiime2, q2-types]
+    test_runner: py.test --pyargs q2_diversity_lib
 
   - name: q2-emperor
     deps: [qiime2, q2templates, q2-types]


### PR DESCRIPTION
Diversity lib's coming on line a year later, following [1](https://github.com/qiime2/busywork/commit/fae30acd0b4c33f8b804c13e02e928936a30e239), [2](https://github.com/qiime2/busywork/commit/9fc8dc69bc5989069fc385a0da17543fbb9fbd33), and a gang of revert commits.