### PR TITLE
ci: adding q2-stats to busywork

### DIFF
--- a/extra/github/variables.yaml
+++ b/extra/github/variables.yaml
@@ -90,6 +90,9 @@ repos:
 
   - name: q2-shogun
 
+  - name: q2-stats
+    action_library_packaging_tests: py.test --pyargs q2_fmt
+
   - name: q2-taxa
     action_library_packaging_tests: py.test --pyargs q2_taxa
 


### PR DESCRIPTION
do not merge before [q2-stats #1](https://github.com/qiime2/q2-stats/pull/1) has been merged